### PR TITLE
feat: add template open and delete actions (#5)

### DIFF
--- a/app/templates/page.tsx
+++ b/app/templates/page.tsx
@@ -23,6 +23,7 @@ export default function TemplatesPage() {
 
   const [templates, setTemplates] = useState<TemplateListItem[]>([]);
   const [creating, setCreating] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   const loadTemplates = useCallback(async () => {
     const items = await store.list();
@@ -45,6 +46,31 @@ export default function TemplatesPage() {
     }
   }, [loadTemplates, router, store]);
 
+  const handleOpen = useCallback(
+    (templateId: string) => {
+      router.push(`/editor/${templateId}`);
+    },
+    [router]
+  );
+
+  const handleDelete = useCallback(
+    async (template: TemplateListItem) => {
+      if (!window.confirm(`Delete template \"${template.name}\"?`)) {
+        return;
+      }
+
+      setDeletingId(template.id);
+
+      try {
+        await store.remove(template.id);
+        await loadTemplates();
+      } finally {
+        setDeletingId(null);
+      }
+    },
+    [loadTemplates, store]
+  );
+
   return (
     <main style={{ padding: "2rem" }}>
       <h1>Templates</h1>
@@ -55,11 +81,31 @@ export default function TemplatesPage() {
       {templates.length === 0 ? (
         <p style={{ marginTop: "1rem" }}>No templates yet.</p>
       ) : (
-        <ul style={{ marginTop: "1rem" }}>
+        <ul style={{ marginTop: "1rem", padding: 0, listStyle: "none", display: "grid", gap: "0.75rem" }}>
           {templates.map((template) => (
-            <li key={template.id}>
-              <strong>{template.name}</strong> ({template.id}) - updated{" "}
-              {formatUpdatedAt(template.updatedAt)}
+            <li
+              key={template.id}
+              style={{ border: "1px solid #ddd", borderRadius: "6px", padding: "0.75rem" }}
+            >
+              <p style={{ margin: 0 }}>
+                <strong>{template.name}</strong>
+              </p>
+              <p style={{ margin: "0.35rem 0", color: "#555", fontSize: "0.9rem" }}>
+                ID: {template.id}
+              </p>
+              <p style={{ margin: 0, color: "#555", fontSize: "0.9rem" }}>
+                Updated {formatUpdatedAt(template.updatedAt)}
+              </p>
+
+              <div style={{ display: "flex", gap: "0.5rem", marginTop: "0.75rem" }}>
+                <button onClick={() => handleOpen(template.id)}>Open</button>
+                <button
+                  onClick={() => void handleDelete(template)}
+                  disabled={deletingId === template.id}
+                >
+                  {deletingId === template.id ? "Deleting..." : "Delete"}
+                </button>
+              </div>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
### Motivation
- Provide in-list actions so users can open a template in the editor or remove it directly from the Templates page as requested by the issue acceptance criteria.
- Make the templates list clearer by showing name, ID, updated timestamp and explicit action buttons for common operations.

### Description
- Added per-row actions to `app/templates/page.tsx`: `Open` navigates to `/editor/[id]` and `Delete` removes the template after a confirmation dialog, with a per-row `deletingId` state to show an in-progress disabled state.
- Updated the templates list item layout to a card-style row that displays the template name, ID, updated timestamp, and the action buttons.
- Implemented deletion by calling the existing `LocalStorageTemplateStore.remove` and reloading the list after removal.
- Closes #5

### Testing
- Ran `npm run build` which completed successfully and produced the optimized build without type errors.
- Started the dev server with `npm run dev` which started and served the app (verified the `/templates` route returned 200 during checks).
- Captured an automated browser screenshot by navigating to `http://localhost:3000/templates` (Playwright script executed and produced the artifact), demonstrating the UI with the new actions.
- Attempted `npm run lint` but the `lint` script is not defined in this repository, so linting was not run automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2fc4ed43c8330b1ba4c5fe48eb49c)