### PR TITLE
feat: add canvas instance duplication control (#8)

### DIFF
--- a/app/editor/[id]/page.tsx
+++ b/app/editor/[id]/page.tsx
@@ -360,6 +360,39 @@ export default function EditorPage() {
     setSaveState("idle");
   }, []);
 
+  const handleDuplicateInstance = useCallback((instanceId: string) => {
+    const nextInstanceId = createInstanceId();
+
+    setDoc((previous) => {
+      if (!previous) {
+        return previous;
+      }
+
+      const index = previous.instances.findIndex((instance) => instance.id === instanceId);
+      if (index < 0) {
+        return previous;
+      }
+
+      const source = previous.instances[index];
+      const duplicate: TemplateInstance = {
+        id: nextInstanceId,
+        componentId: source.componentId,
+        overrides: { ...source.overrides }
+      };
+
+      const nextInstances = [...previous.instances];
+      nextInstances.splice(index + 1, 0, duplicate);
+
+      return {
+        ...previous,
+        instances: nextInstances
+      };
+    });
+
+    setSelectedInstanceId(nextInstanceId);
+    setSaveState("idle");
+  }, []);
+
   const handleSave = useCallback(async () => {
     if (!doc) {
       return;
@@ -528,6 +561,9 @@ export default function EditorPage() {
                         style={{ flex: 1 }}
                       >
                         Move Down
+                      </button>
+                      <button onClick={() => handleDuplicateInstance(instance.id)}>
+                        Duplicate
                       </button>
                       <button onClick={() => handleDeleteInstance(instance.id)}>Delete</button>
                     </div>


### PR DESCRIPTION
### Motivation
- Provide a quick way for users to clone an existing canvas component instance so they can reuse and tweak components without re-adding and reconfiguring them manually.

### Description
- Added `handleDuplicateInstance` to `app/editor/[id]/page.tsx` which creates a new instance id, copies `componentId` and `overrides`, inserts the duplicate immediately after the source instance, and selects the new instance.
- Added a `Duplicate` button to each canvas instance control row wired to the new handler so duplication is available in the editor UI.
- Change is frontend-only and localized to `app/editor/[id]/page.tsx`.
- Closes #8

### Testing
- Ran `npm run build` which completed successfully and produced an optimized production build.
- Started the dev server with `npm run dev` and confirmed the editor loads and the new button is present; the server started successfully.
- Attempted `npm run lint` but the project has no `lint` script in package.json, so this check is unavailable in this environment.
- Executed a small automated Playwright smoke script that created a template, added a component, clicked `Duplicate`, and produced a screenshot artifact confirming the button and UI flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5afb6b8e083309156867463b46d02)