### PR TITLE
feat: improve canvas instance labels (#9)

### DIFF
--- a/app/editor/[id]/page.tsx
+++ b/app/editor/[id]/page.tsx
@@ -449,6 +449,8 @@ export default function EditorPage() {
     ? getComponentDefaults(selectedComponent)
     : {};
 
+  const componentNameById = new Map(components.map((component) => [component.id, component.name]));
+
   return (
     <main style={{ padding: "1rem" }}>
       <header
@@ -544,7 +546,12 @@ export default function EditorPage() {
                           instance.id === selectedInstanceId ? "#eff6ff" : "#fff"
                       }}
                     >
-                      {instance.componentId} ({instance.id})
+                      <span style={{ display: "block", fontWeight: 600 }}>
+                        {index + 1}. {componentNameById.get(instance.componentId) ?? instance.componentId}
+                      </span>
+                      <span style={{ display: "block", fontSize: "0.8rem", color: "#555" }}>
+                        {instance.id}
+                      </span>
                     </button>
 
                     <div style={{ display: "flex", gap: "0.35rem" }}>


### PR DESCRIPTION
### Motivation
- Improve readability of canvas instance entries so users can quickly identify an instance's order and component type in the editor.

### Description
- Updated `app/editor/[id]/page.tsx` to add a `componentNameById` lookup and render each canvas item with a 1-based index, the human-readable component name (fallback to `componentId`), and the instance ID on a secondary line; this is a frontend-only change and closes #9.

### Testing
- Ran automated checks: `npm run lint` failed because the repository does not define a `lint` script, `npm run build` completed successfully, and `npm run dev` started the dev server and an automated Playwright script exercised the templates→editor flow and produced a screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b219da7883309436e88c74dbf2ab)