### PR TITLE
feat: confirm canvas instance deletion (#10)

### DIFF
--- a/app/editor/[id]/page.tsx
+++ b/app/editor/[id]/page.tsx
@@ -360,6 +360,27 @@ export default function EditorPage() {
     setSaveState("idle");
   }, []);
 
+  const componentNameById = useMemo(
+    () => new Map(components.map((component) => [component.id, component.name])),
+    [components]
+  );
+
+  const confirmDeleteInstance = useCallback(
+    (instance: TemplateInstance, index: number) => {
+      const componentName = componentNameById.get(instance.componentId) ?? instance.componentId;
+      const shouldDelete = window.confirm(
+        `Delete component ${index + 1}: ${componentName}?`
+      );
+
+      if (!shouldDelete) {
+        return;
+      }
+
+      handleDeleteInstance(instance.id);
+    },
+    [componentNameById, handleDeleteInstance]
+  );
+
   const handleDuplicateInstance = useCallback((instanceId: string) => {
     const nextInstanceId = createInstanceId();
 
@@ -449,7 +470,6 @@ export default function EditorPage() {
     ? getComponentDefaults(selectedComponent)
     : {};
 
-  const componentNameById = new Map(components.map((component) => [component.id, component.name]));
 
   return (
     <main style={{ padding: "1rem" }}>
@@ -572,7 +592,9 @@ export default function EditorPage() {
                       <button onClick={() => handleDuplicateInstance(instance.id)}>
                         Duplicate
                       </button>
-                      <button onClick={() => handleDeleteInstance(instance.id)}>Delete</button>
+                      <button onClick={() => confirmDeleteInstance(instance, index)}>
+                        Delete
+                      </button>
                     </div>
                   </div>
                 </li>


### PR DESCRIPTION
### Motivation
- Prevent accidental removal of canvas component instances by prompting the user to confirm deletion before the instance is removed.

### Description
- Added a memoized `componentNameById` map and a `confirmDeleteInstance` callback to `app/editor/[id]/page.tsx` to show a browser confirmation dialog with instance order and component name. 
- The `confirmDeleteInstance` callback uses `window.confirm` and delegates to the existing `handleDeleteInstance` when the user confirms. 
- Replaced the canvas Delete button to call `confirmDeleteInstance` so deletion is gated by confirmation. 
- Modified file: `app/editor/[id]/page.tsx`. Closes #10.

### Testing
- Ran `npm run lint` which failed because this repository does not define a `lint` script in `package.json`. 
- Ran `npm run build` which completed successfully. 
- Ran `npm run dev` which started the development server successfully. 
- Executed an automated Playwright script that opened `/templates`, created a template, added a component, and captured a screenshot, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b8c114208330af08cd0608d2ede5)