### PR TITLE
feat: add clear canvas action in editor (#11)

### DIFF
--- a/app/editor/[id]/page.tsx
+++ b/app/editor/[id]/page.tsx
@@ -414,6 +414,27 @@ export default function EditorPage() {
     setSaveState("idle");
   }, []);
 
+  const handleClearCanvas = useCallback(() => {
+    const shouldClear = window.confirm("Delete all components from the canvas?");
+    if (!shouldClear) {
+      return;
+    }
+
+    setDoc((previous) => {
+      if (!previous || previous.instances.length === 0) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        instances: []
+      };
+    });
+
+    setSelectedInstanceId(null);
+    setSaveState("idle");
+  }, []);
+
   const handleSave = useCallback(async () => {
     if (!doc) {
       return;
@@ -542,7 +563,20 @@ export default function EditorPage() {
         </aside>
 
         <section style={{ border: "1px solid #ddd", borderRadius: "6px", padding: "0.75rem" }}>
-          <h2 style={{ marginTop: 0 }}>Canvas</h2>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: "0.5rem",
+              marginBottom: "0.75rem"
+            }}
+          >
+            <h2 style={{ margin: 0 }}>Canvas</h2>
+            <button onClick={handleClearCanvas} disabled={doc.instances.length === 0}>
+              Clear Canvas
+            </button>
+          </div>
 
           {doc.instances.length === 0 ? (
             <p>No components added yet.</p>


### PR DESCRIPTION
### Motivation
- Provide a quick way for users to remove all component instances from the editor canvas in one action as requested by Issue #11.

### Description
- Added `handleClearCanvas` to `app/editor/[id]/page.tsx` which shows a confirmation, clears `doc.instances`, resets the selected instance, and marks the document as unsaved.
- Updated the Canvas header to include a `Clear Canvas` button that is disabled when there are no instances and wired it to `handleClearCanvas`.
- Changes are localized to a single file: `app/editor/[id]/page.tsx` and committed on branch `feat/11-clear-canvas`; Closes #11.

### Testing
- Ran `npm run build` and the Next.js production build completed successfully.
- Started the dev server with `npm run dev` and the app compiled and served pages locally.
- Attempted `npm run lint` but the repository does not define a `lint` script so linting was not executed.
- Attempted an automated Playwright validation but the headless browser crashed in this environment so the end-to-end screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5beae3f98833098c721e356b46171)