### PR TITLE
feat: show save shortcut hint in editor button (#23)

### DIFF
--- a/app/editor/[id]/page.tsx
+++ b/app/editor/[id]/page.tsx
@@ -186,6 +186,14 @@ export default function EditorPage() {
   const [savedAt, setSavedAt] = useState<string | null>(null);
   const [savedSnapshot, setSavedSnapshot] = useState<string>("");
 
+  const saveShortcutLabel = useMemo(() => {
+    if (typeof navigator === "undefined") {
+      return "Ctrl+S";
+    }
+
+    return /Mac|iPhone|iPad|iPod/i.test(navigator.platform) ? "⌘S" : "Ctrl+S";
+  }, []);
+
   const loadTemplate = useCallback(async () => {
     if (!templateId) {
       setNotFound(true);
@@ -635,8 +643,9 @@ export default function EditorPage() {
           <button
             onClick={() => void handleSave()}
             disabled={saveState === "saving" || !hasUnsavedChanges}
+            aria-keyshortcuts="Control+S Meta+S"
           >
-            {saveState === "saving" ? "Saving..." : "Save"}
+            {saveState === "saving" ? "Saving..." : `Save (${saveShortcutLabel})`}
           </button>
           <button onClick={handleExport}>Export HTML</button>
           <span className="text-sm text-slate-700">


### PR DESCRIPTION
### Motivation
- Provide a visible keyboard shortcut hint on the editor Save button so users can discover the existing save shortcut (Ctrl/⌘+S).

### Description
- Added a platform-aware `saveShortcutLabel` (using `navigator.platform`) and appended it to the Save button label, and added `aria-keyshortcuts="Control+S Meta+S"` for accessibility in `app/editor/[id]/page.tsx`, which implements the requested behavior and closes #23.

### Testing
- Ran `npm run build` and the Next.js production build completed successfully.
- Started the dev server with `npm run dev` and it reported ready (server started successfully).
- `npm run lint` failed because the repository does not define a `lint` script in `package.json`.
- An automated Playwright screenshot attempt failed due to the headless Chromium process crashing in the execution environment (environment-specific failure, not application code).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80d6f91ac83308d7212acaaa6adf4)